### PR TITLE
base-pom release 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: java
 
 sudo: false
 
-jdk: oraclejdk8
+jdk: oraclejdk9
 
 script: mvn clean install -P full-build

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 The POM module provides a parent pom which is also use in the GroundWork Project. It is part of the GroundWork Project by Viascom.
 
 ## Version:
-[![release](https://img.shields.io/badge/release-v1.7-brightgreen.svg)](https://github.com/Viascom/groundwork/tree/master/pom)<br/>
-[![develop](https://img.shields.io/badge/develop-v1.7-brightgreen.svg)](https://github.com/Viascom/groundwork/tree/develop/pom)
+[![release](https://img.shields.io/badge/release-v1.8-brightgreen.svg)](https://github.com/Viascom/groundwork/tree/master/pom)<br/>
+[![develop](https://img.shields.io/badge/develop-v1.8-brightgreen.svg)](https://github.com/Viascom/groundwork/tree/develop/pom)
 
 ## Profiles:
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ch.viascom.groundwork</groupId>
     <artifactId>pom</artifactId>
-    <version>1.7</version>
+    <version>1.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>base-pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -515,6 +515,13 @@
                 <artifactId>commons-math3</artifactId>
                 <version>3.6.1</version>
             </dependency>
+
+            <!-- A Java implementation of JSON Web Tokens -->
+            <dependency>
+                <groupId>com.auth0</groupId>
+                <artifactId>java-jwt</artifactId>
+                <version>3.3.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ch.viascom.groundwork</groupId>
     <artifactId>pom</artifactId>
-    <version>1.8-SNAPSHOT</version>
+    <version>1.8</version>
     <packaging>pom</packaging>
 
     <name>base-pom</name>
@@ -70,6 +70,7 @@
     <properties>
         <jdkLevel>1.8</jdkLevel>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Default applicationserver properties -->
         <applicationserver.wildfly.hostname>localhost</applicationserver.wildfly.hostname>
@@ -409,7 +410,7 @@
             <dependency>
                 <groupId>ch.viascom.groundwork</groupId>
                 <artifactId>foxhttp</artifactId>
-                <version>1.3</version>
+                <version>1.3.1</version>
             </dependency>
 
             <!-- Lombock -->
@@ -430,7 +431,7 @@
             <dependency>
                 <groupId>org.joda</groupId>
                 <artifactId>joda-convert</artifactId>
-                <version>1.9.2</version>
+                <version>2.0</version>
             </dependency>
 
             <!-- Logging -->
@@ -479,7 +480,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.13.0</version>
+                <version>2.15.0</version>
                 <scope>test</scope>
             </dependency>
 
@@ -494,7 +495,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>23.6-jre</version>
+                <version>24.0-jre</version>
             </dependency>
 
             <!-- Apache Commons -->
@@ -638,7 +639,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.21.0</version>
                     <configuration>
                         <excludes>
                             <exclude>**/*$*</exclude>
@@ -751,7 +752,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5</version>
+                    <version>3.5.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -801,12 +802,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.8</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -447,34 +447,18 @@
                 <version>2.10.0</version>
             </dependency>
 
-            <!-- Java EE 8 -->
-            <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-api</artifactId>
-                <version>8.0</version>
-            </dependency>
-
-            <!-- CDI API -->
-            <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>2.0.Beta1</version>
-                <scope>provided</scope>
-            </dependency>
-
             <!-- Testing -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.1.0</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
-                <groupId>org.easytesting</groupId>
-                <artifactId>fest-assert-core</artifactId>
-                <version>2.0M10</version>
-                <scope>test</scope>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>5.1.0</version>
             </dependency>
 
             <dependency>
@@ -538,7 +522,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <encoding>utf-8</encoding>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                     <source>${jdkLevel}</source>
                     <target>${jdkLevel}</target>
                 </configuration>
@@ -632,7 +616,7 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <encoding>utf-8</encoding>
+                        <encoding>${project.build.sourceEncoding}</encoding>
                         <source>${jdkLevel}</source>
                         <target>${jdkLevel}</target>
                     </configuration>


### PR DESCRIPTION
- added project.reporting.outputEncoding --> UTF-8
- updated dependencies to newest versions
- added java-jwt from auth0
- updated travis to build with oracle jdk 9
